### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ First of all, let's install some global tools
 
 Now clone the source and install project dependencies:
 ```
-# git clone git://github.com:nokiadatagathering/MDGServer.git
+# git clone git://github.com/nokiadatagathering/MDGServer.git
 # cd MDGServer
 # npm install
 # bower install


### PR DESCRIPTION
changed : to a / in the giot checkout. Users were getting  the following error "github.com:` ServName

> '? supported for `No ai_socktype'",
